### PR TITLE
Fix to overlapped header in version 0.3.1.

### DIFF
--- a/src/CalendarHeader.tsx
+++ b/src/CalendarHeader.tsx
@@ -40,29 +40,27 @@ export const CalendarHeader = React.memo(
               disabled={onPressDateHeader === undefined}
               key={date.toString()}
             >
-              <View style={{ flex: 1, paddingTop: 2 }}>
-                <View style={{ height: cellHeight, justifyContent: 'space-between' }}>
-                  <Text style={[commonStyles.guideText, _isToday && { color: PRIMARY_COLOR }]}>
-                    {date.format('ddd')}
+              <View style={{ height: cellHeight, justifyContent: 'space-between' }}>
+                <Text style={[commonStyles.guideText, _isToday && { color: PRIMARY_COLOR }]}>
+                  {date.format('ddd')}
+                </Text>
+                <View style={_isToday && styles.todayWrap}>
+                  <Text style={[styles.dateText, _isToday && { color: '#fff' }]}>
+                    {date.format('D')}
                   </Text>
-                  <View style={_isToday && styles.todayWrap}>
-                    <Text style={[styles.dateText, _isToday && { color: '#fff' }]}>
-                      {date.format('D')}
-                    </Text>
-                  </View>
                 </View>
-                <View style={[commonStyles.dateCell, { height: cellHeight }]}>
-                  {allDayEvents.map((event) => {
-                    if (!event.start.isSame(date, 'day')) {
-                      return null
-                    }
-                    return (
-                      <View style={commonStyles.eventCell}>
-                        <Text style={commonStyles.eventTitle}>{event.title}</Text>
-                      </View>
-                    )
-                  })}
-                </View>
+              </View>
+              <View style={[commonStyles.dateCell, { height: cellHeight }]}>
+                {allDayEvents.map((event) => {
+                  if (!event.start.isSame(date, 'day')) {
+                    return null
+                  }
+                  return (
+                    <View style={commonStyles.eventCell}>
+                      <Text style={commonStyles.eventTitle}>{event.title}</Text>
+                    </View>
+                  )
+                })}
               </View>
             </TouchableOpacity>
           )


### PR DESCRIPTION
This is from the latest version 0.3.1. 
It works fine in Storybook and in a react-native project this is what it looks like.

![image](https://user-images.githubusercontent.com/62530919/81461716-48e6ab80-91e0-11ea-9357-f3add084e1b0.png)

This is caused by an extra `View` under the `TouchableOpacity` in `CalendarHeader.tsx`.