### PR TITLE
Interface headerProps intermediate variable

### DIFF
--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -10,6 +10,7 @@ import {
   DateRangeHandler,
   EventCellStyle,
   EventRenderer,
+  HeaderRendererProps,
   HeaderRenderer,
   HorizontalDirection,
   HourRenderer,
@@ -372,7 +373,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
     )
   }
 
-  const headerProps = {
+  const headerProps: HeaderRendererProps<T> = {
     ...commonProps,
     style: headerContainerStyle,
     headerContainerAccessibilityProps: headerContainerAccessibilityProps,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,9 +57,14 @@ export type EventRenderer<T extends ICalendarEventBase = ICalendarEventBase> = (
   touchableOpacityProps: CalendarTouchableOpacityProps,
 ) => JSX.Element
 
+export type HeaderRendererProps<T extends ICalendarEventBase> = CalendarHeaderProps<T> & {
+  mode: Mode
+}
+
 export type HeaderRenderer<T extends ICalendarEventBase> = React.ComponentType<
-  CalendarHeaderProps<T> & { mode: Mode }
+  HeaderRendererProps<T>
 >
+
 export type MonthHeaderRenderer = React.ComponentType<CalendarHeaderForMonthViewProps>
 
 export type HourRenderer = React.ComponentType<{ ampm: boolean; hour: number }>


### PR DESCRIPTION
The type information would be added for the headerProps intermediate variable in the CalendarContainer component. But not for the month mode, because in this mode the header is implemented with the CalendarHeaderForMonthView component. A new interface HeaderRendererProps was created for this purpose, which summarises the CalendarHeaderProps and the type of the mode property.

I'm not entirely sure that the changes to the types are 100% correct or even necessary. Please check before merging.