### PR TITLE
fix(month-mode): remove unnecessary setPage call in onPressCell handler

### DIFF
--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -383,10 +383,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
               hideNowIndicator={hideNowIndicator}
               showAdjacentMonths={showAdjacentMonths}
               onLongPressCell={onLongPressCell}
-              onPressCell={(date) => {
-                onPressCell?.(date)
-                calendarRef.current?.setPage(0, { animated: true })
-              }}
+              onPressCell={onPressCell}
               onPressDateHeader={onPressDateHeader}
               onPressEvent={onPressEvent}
               renderEvent={renderEvent}


### PR DESCRIPTION
- Eliminate `calendarRef.current?.setPage(0, { animated: true })` invocation triggered by cell presses in month mode
- Keep the original `onPressCell` logic intact
