### PR TITLE
ci: pin actions/cache to @v4 instead of @master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/cache@master
+      - uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/cache@master
+      - uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Summary

`actions/cache@master` is deprecated and unstable — the action no longer maintains a usable `master` ref, and pinning to a moving branch is discouraged. This pins both workflows to the current stable major tag `@v4`.

## Changes

- `.github/workflows/test.yml`: `actions/cache@master` → `@v4`
- `.github/workflows/release.yml`: `actions/cache@master` → `@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)